### PR TITLE
refactor: remove mutex in stream reader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1182,6 +1182,7 @@ dependencies = [
  "opentelemetry-proto",
  "paste",
  "prost",
+ "rand",
  "serde",
  "snafu",
  "tonic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,8 @@ serde = { version = "1.0", features = ["derive"] }
 snafu = { version = "0.8" }
 tonic = "0.12"
 
+[dev-dependencies]
+rand = "0.8"
+
 [build-dependencies]
 tonic-build = "0.12"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,8 @@ mod error;
 mod otlp;
 #[allow(dead_code)]
 mod schema;
+#[cfg(test)]
+mod test_util;
 
 #[path = ""]
 pub mod opentelemetry {

--- a/src/proto/opentelemetry.proto.experimental.arrow.v1.rs
+++ b/src/proto/opentelemetry.proto.experimental.arrow.v1.rs
@@ -215,10 +215,10 @@ pub mod arrow_traces_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// ArrowTracesService is a traces-only Arrow stream.
     #[derive(Debug, Clone)]
     pub struct ArrowTracesServiceClient<T> {
@@ -263,8 +263,9 @@ pub mod arrow_traces_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             ArrowTracesServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -306,18 +307,26 @@ pub mod arrow_traces_service_client {
             tonic::Response<tonic::codec::Streaming<super::BatchStatus>>,
             tonic::Status,
         > {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/opentelemetry.proto.experimental.arrow.v1.ArrowTracesService/ArrowTraces",
             );
             let mut req = request.into_streaming_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "opentelemetry.proto.experimental.arrow.v1.ArrowTracesService",
-                "ArrowTraces",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "opentelemetry.proto.experimental.arrow.v1.ArrowTracesService",
+                        "ArrowTraces",
+                    ),
+                );
             self.inner.streaming(req, path, codec).await
         }
     }
@@ -330,10 +339,10 @@ pub mod arrow_logs_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// ArrowTracesService is a logs-only Arrow stream.
     #[derive(Debug, Clone)]
     pub struct ArrowLogsServiceClient<T> {
@@ -378,8 +387,9 @@ pub mod arrow_logs_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             ArrowLogsServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -421,18 +431,26 @@ pub mod arrow_logs_service_client {
             tonic::Response<tonic::codec::Streaming<super::BatchStatus>>,
             tonic::Status,
         > {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/opentelemetry.proto.experimental.arrow.v1.ArrowLogsService/ArrowLogs",
             );
             let mut req = request.into_streaming_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "opentelemetry.proto.experimental.arrow.v1.ArrowLogsService",
-                "ArrowLogs",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "opentelemetry.proto.experimental.arrow.v1.ArrowLogsService",
+                        "ArrowLogs",
+                    ),
+                );
             self.inner.streaming(req, path, codec).await
         }
     }
@@ -445,10 +463,10 @@ pub mod arrow_metrics_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// ArrowTracesService is a metrics-only Arrow stream.
     #[derive(Debug, Clone)]
     pub struct ArrowMetricsServiceClient<T> {
@@ -493,8 +511,9 @@ pub mod arrow_metrics_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             ArrowMetricsServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -536,18 +555,26 @@ pub mod arrow_metrics_service_client {
             tonic::Response<tonic::codec::Streaming<super::BatchStatus>>,
             tonic::Status,
         > {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/opentelemetry.proto.experimental.arrow.v1.ArrowMetricsService/ArrowMetrics",
             );
             let mut req = request.into_streaming_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "opentelemetry.proto.experimental.arrow.v1.ArrowMetricsService",
-                "ArrowMetrics",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "opentelemetry.proto.experimental.arrow.v1.ArrowMetricsService",
+                        "ArrowMetrics",
+                    ),
+                );
             self.inner.streaming(req, path, codec).await
         }
     }
@@ -560,7 +587,7 @@ pub mod arrow_traces_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with ArrowTracesServiceServer.
@@ -569,12 +596,16 @@ pub mod arrow_traces_service_server {
         /// Server streaming response type for the ArrowTraces method.
         type ArrowTracesStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::BatchStatus, tonic::Status>,
-            > + std::marker::Send
+            >
+            + std::marker::Send
             + 'static;
         async fn arrow_traces(
             &self,
             request: tonic::Request<tonic::Streaming<super::BatchArrowRecords>>,
-        ) -> std::result::Result<tonic::Response<Self::ArrowTracesStream>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<Self::ArrowTracesStream>,
+            tonic::Status,
+        >;
     }
     /// ArrowTracesService is a traces-only Arrow stream.
     #[derive(Debug)]
@@ -598,7 +629,10 @@ pub mod arrow_traces_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -653,21 +687,26 @@ pub mod arrow_traces_service_server {
                 "/opentelemetry.proto.experimental.arrow.v1.ArrowTracesService/ArrowTraces" => {
                     #[allow(non_camel_case_types)]
                     struct ArrowTracesSvc<T: ArrowTracesService>(pub Arc<T>);
-                    impl<T: ArrowTracesService>
-                        tonic::server::StreamingService<super::BatchArrowRecords>
-                        for ArrowTracesSvc<T>
-                    {
+                    impl<
+                        T: ArrowTracesService,
+                    > tonic::server::StreamingService<super::BatchArrowRecords>
+                    for ArrowTracesSvc<T> {
                         type Response = super::BatchStatus;
                         type ResponseStream = T::ArrowTracesStream;
-                        type Future =
-                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<tonic::Streaming<super::BatchArrowRecords>>,
+                            request: tonic::Request<
+                                tonic::Streaming<super::BatchArrowRecords>,
+                            >,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as ArrowTracesService>::arrow_traces(&inner, request).await
+                                <T as ArrowTracesService>::arrow_traces(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -694,19 +733,23 @@ pub mod arrow_traces_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
-                    let headers = response.headers_mut();
-                    headers.insert(
-                        tonic::Status::GRPC_STATUS,
-                        (tonic::Code::Unimplemented as i32).into(),
-                    );
-                    headers.insert(
-                        http::header::CONTENT_TYPE,
-                        tonic::metadata::GRPC_CONTENT_TYPE,
-                    );
-                    Ok(response)
-                }),
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(empty_body());
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
             }
         }
     }
@@ -736,7 +779,7 @@ pub mod arrow_logs_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with ArrowLogsServiceServer.
@@ -745,7 +788,8 @@ pub mod arrow_logs_service_server {
         /// Server streaming response type for the ArrowLogs method.
         type ArrowLogsStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::BatchStatus, tonic::Status>,
-            > + std::marker::Send
+            >
+            + std::marker::Send
             + 'static;
         async fn arrow_logs(
             &self,
@@ -774,7 +818,10 @@ pub mod arrow_logs_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -829,17 +876,21 @@ pub mod arrow_logs_service_server {
                 "/opentelemetry.proto.experimental.arrow.v1.ArrowLogsService/ArrowLogs" => {
                     #[allow(non_camel_case_types)]
                     struct ArrowLogsSvc<T: ArrowLogsService>(pub Arc<T>);
-                    impl<T: ArrowLogsService>
-                        tonic::server::StreamingService<super::BatchArrowRecords>
-                        for ArrowLogsSvc<T>
-                    {
+                    impl<
+                        T: ArrowLogsService,
+                    > tonic::server::StreamingService<super::BatchArrowRecords>
+                    for ArrowLogsSvc<T> {
                         type Response = super::BatchStatus;
                         type ResponseStream = T::ArrowLogsStream;
-                        type Future =
-                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<tonic::Streaming<super::BatchArrowRecords>>,
+                            request: tonic::Request<
+                                tonic::Streaming<super::BatchArrowRecords>,
+                            >,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
@@ -870,19 +921,23 @@ pub mod arrow_logs_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
-                    let headers = response.headers_mut();
-                    headers.insert(
-                        tonic::Status::GRPC_STATUS,
-                        (tonic::Code::Unimplemented as i32).into(),
-                    );
-                    headers.insert(
-                        http::header::CONTENT_TYPE,
-                        tonic::metadata::GRPC_CONTENT_TYPE,
-                    );
-                    Ok(response)
-                }),
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(empty_body());
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
             }
         }
     }
@@ -912,7 +967,7 @@ pub mod arrow_metrics_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with ArrowMetricsServiceServer.
@@ -921,12 +976,16 @@ pub mod arrow_metrics_service_server {
         /// Server streaming response type for the ArrowMetrics method.
         type ArrowMetricsStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::BatchStatus, tonic::Status>,
-            > + std::marker::Send
+            >
+            + std::marker::Send
             + 'static;
         async fn arrow_metrics(
             &self,
             request: tonic::Request<tonic::Streaming<super::BatchArrowRecords>>,
-        ) -> std::result::Result<tonic::Response<Self::ArrowMetricsStream>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<Self::ArrowMetricsStream>,
+            tonic::Status,
+        >;
     }
     /// ArrowTracesService is a metrics-only Arrow stream.
     #[derive(Debug)]
@@ -950,7 +1009,10 @@ pub mod arrow_metrics_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -1005,21 +1067,26 @@ pub mod arrow_metrics_service_server {
                 "/opentelemetry.proto.experimental.arrow.v1.ArrowMetricsService/ArrowMetrics" => {
                     #[allow(non_camel_case_types)]
                     struct ArrowMetricsSvc<T: ArrowMetricsService>(pub Arc<T>);
-                    impl<T: ArrowMetricsService>
-                        tonic::server::StreamingService<super::BatchArrowRecords>
-                        for ArrowMetricsSvc<T>
-                    {
+                    impl<
+                        T: ArrowMetricsService,
+                    > tonic::server::StreamingService<super::BatchArrowRecords>
+                    for ArrowMetricsSvc<T> {
                         type Response = super::BatchStatus;
                         type ResponseStream = T::ArrowMetricsStream;
-                        type Future =
-                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<tonic::Streaming<super::BatchArrowRecords>>,
+                            request: tonic::Request<
+                                tonic::Streaming<super::BatchArrowRecords>,
+                            >,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as ArrowMetricsService>::arrow_metrics(&inner, request).await
+                                <T as ArrowMetricsService>::arrow_metrics(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -1046,19 +1113,23 @@ pub mod arrow_metrics_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
-                    let headers = response.headers_mut();
-                    headers.insert(
-                        tonic::Status::GRPC_STATUS,
-                        (tonic::Code::Unimplemented as i32).into(),
-                    );
-                    headers.insert(
-                        http::header::CONTENT_TYPE,
-                        tonic::metadata::GRPC_CONTENT_TYPE,
-                    );
-                    Ok(response)
-                }),
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(empty_body());
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
             }
         }
     }

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -1,0 +1,92 @@
+use arrow::array::{
+    ArrayRef, BinaryArray, BooleanArray, Float32Array, Float64Array,
+    Int16Array, Int32Array, Int64Array, Int8Array, RecordBatch, StringArray,
+    TimestampMicrosecondArray, TimestampMillisecondArray, TimestampNanosecondArray,
+    TimestampSecondArray, UInt16Array, UInt32Array, UInt64Array, UInt8Array,
+};
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit};
+use rand::distributions::{Alphanumeric, DistString};
+use rand::Rng;
+use std::sync::Arc;
+
+pub(crate) fn create_test_schema() -> Schema {
+    Schema::new(vec![
+        Field::new("a", DataType::UInt16, true),
+        Field::new("b", DataType::Utf8, true),
+        Field::new("c", DataType::Float64, true),
+    ])
+}
+
+pub(crate) fn create_record_batch(schema: SchemaRef, num_rows: usize) -> RecordBatch {
+    let columns = schema
+        .fields
+        .iter()
+        .map(|f| create_array(f.data_type(), num_rows))
+        .collect::<Vec<_>>();
+    RecordBatch::try_new(schema, columns).unwrap()
+}
+
+pub(crate) fn create_array(dt: &DataType, num_rows: usize) -> ArrayRef {
+    let mut r = rand::thread_rng();
+    match dt {
+        DataType::Boolean => Arc::new(
+            (0..num_rows)
+                .map(|_| Some(r.gen_bool(1.0 / 2.0)))
+                .collect::<BooleanArray>(),
+        ) as Arc<_>,
+        DataType::Int8 => {
+            Arc::new(Int8Array::from_iter((0..num_rows).map(|_| r.gen::<i8>()))) as Arc<_>
+        }
+        DataType::Int16 => {
+            Arc::new(Int16Array::from_iter((0..num_rows).map(|_| r.gen::<i16>()))) as Arc<_>
+        }
+        DataType::Int32 => {
+            Arc::new(Int32Array::from_iter((0..num_rows).map(|_| r.gen::<i32>()))) as Arc<_>
+        }
+        DataType::Int64 => {
+            Arc::new(Int64Array::from_iter((0..num_rows).map(|_| r.gen::<i64>()))) as Arc<_>
+        }
+        DataType::UInt8 => {
+            Arc::new(UInt8Array::from_iter((0..num_rows).map(|_| r.gen::<u8>()))) as Arc<_>
+        }
+        DataType::UInt16 => Arc::new(UInt16Array::from_iter(
+            (0..num_rows).map(|_| r.gen::<u16>()),
+        )) as Arc<_>,
+        DataType::UInt32 => Arc::new(UInt32Array::from_iter(
+            (0..num_rows).map(|_| r.gen::<u32>()),
+        )) as Arc<_>,
+        DataType::UInt64 => Arc::new(UInt64Array::from_iter(
+            (0..num_rows).map(|_| r.gen::<u64>()),
+        )) as Arc<_>,
+        DataType::Float32 => Arc::new(Float32Array::from_iter(
+            (0..num_rows).map(|_| r.gen::<f32>()),
+        )) as Arc<_>,
+        DataType::Float64 => Arc::new(Float64Array::from_iter(
+            (0..num_rows).map(|_| r.gen::<f64>()),
+        )) as Arc<_>,
+        DataType::Timestamp(unit, _) => match unit {
+            TimeUnit::Second => Arc::new(TimestampSecondArray::from_iter(&Int64Array::from_iter(
+                (0..num_rows).map(|_| r.gen::<i64>()),
+            ))) as Arc<_>,
+            TimeUnit::Millisecond => Arc::new(TimestampMillisecondArray::from_iter(
+                &Int64Array::from_iter((0..num_rows).map(|_| r.gen::<i64>())),
+            )) as Arc<_>,
+            TimeUnit::Microsecond => Arc::new(TimestampMicrosecondArray::from_iter(
+                &Int64Array::from_iter((0..num_rows).map(|_| r.gen::<i64>())),
+            )) as Arc<_>,
+
+            TimeUnit::Nanosecond => Arc::new(TimestampNanosecondArray::from_iter(
+                &Int64Array::from_iter((0..num_rows).map(|_| r.gen::<i64>())),
+            )) as Arc<_>,
+        },
+        DataType::Binary | DataType::LargeBinary => Arc::new(BinaryArray::from_iter(
+            (0..num_rows).map(|_| Some(Alphanumeric.sample_string(&mut r, 10))),
+        )) as Arc<_>,
+        DataType::Utf8 => Arc::new(StringArray::from_iter(
+            (0..num_rows).map(|_| Some(Alphanumeric.sample_string(&mut r, 10))),
+        )) as Arc<_>,
+        _ => {
+            unimplemented!()
+        }
+    }
+}

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -1,3 +1,15 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use arrow::array::{
     ArrayRef, BinaryArray, BooleanArray, Float32Array, Float64Array,
     Int16Array, Int32Array, Int64Array, Int8Array, RecordBatch, StringArray,


### PR DESCRIPTION
 Add rand as dev-dependency and refactor StreamConsumer

 - Simplify `StreamConsumer` by removing `SharedReader` and using `Cursor` directly.
 - Implement `replace_bytes` method directly on `StreamConsumer`.